### PR TITLE
Fix module load for config

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -55,7 +55,7 @@
   </div>
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jszip/3.10.1/jszip.min.js"></script>
-  <script src="config.js"></script>
+  <script type="module" src="config.js"></script>
   <script type="module" src="firebase-config.js"></script>
   <script type="module" src="auth.js"></script>
   <script type="module" src="main.js"></script>


### PR DESCRIPTION
## Summary
- load `config.js` as a module so other modules can import from it

## Testing
- `python -m py_compile backend/*.py`

------
https://chatgpt.com/codex/tasks/task_e_685010e86b24832d9d36691c0a9a81ce