### PR TITLE
Remove sensitive env.js and improve setup docs

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -2,7 +2,8 @@
 
 This frontend relies on Firebase for authentication and usage tracking.
 Sensitive credentials are not stored in version control. To run the frontend you
-must provide them in a local `env.js` file.
+must first create a local `env.js` file by copying `env.example.js` and filling
+in your own Firebase project keys.
 
 ## Configuration
 

--- a/frontend/env.js
+++ b/frontend/env.js
@@ -1,8 +1,0 @@
-window.env = {
-  FIREBASE_API_KEY: "AIzaSyBlOV6dMrcj50p_xrlA76HIrxMAP_Jaqm0",
-  FIREBASE_AUTH_DOMAIN: "png-webp-jpeg-image-converter.firebaseapp.com",
-  FIREBASE_PROJECT_ID: "png-webp-jpeg-image-converter",
-  FIREBASE_STORAGE_BUCKET: "png-webp-jpeg-image-converter.appspot.com",
-  FIREBASE_MESSAGING_SENDER_ID: "538545308492",
-  FIREBASE_APP_ID: "1:538545308492:web:custom_app_id",
-};


### PR DESCRIPTION
## Summary
- delete `env.js` to keep Firebase keys out of the repo
- document copying `env.example.js` for local configuration

## Testing
- `python -m py_compile backend/*.py`

------
https://chatgpt.com/codex/tasks/task_e_68529f7e4078832d8d72a7d7d7cc4ce0