### PR TITLE
Make allowed origins configurable

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -13,6 +13,17 @@ This is a FastAPI-based backend for converting up to 10 uploaded images to the d
 - Uses `Pillow` and `python-multipart`
 - Separated logic in `converter.py`
 
+### CORS configuration
+
+The backend reads allowed origins from the `FRONTEND_ORIGINS` environment
+variable. Provide a comma-separated list of frontend URLs, e.g.:
+
+```bash
+export FRONTEND_ORIGINS="http://localhost:8080,https://myapp.example.com"
+```
+
+When not set, all origins are allowed (useful for local development).
+
 ---
 
 ## 🛠 Local Run

--- a/backend/main.py
+++ b/backend/main.py
@@ -3,14 +3,24 @@ from fastapi.responses import StreamingResponse
 from fastapi.middleware.cors import CORSMiddleware
 from typing import List
 from io import BytesIO
+import os
 from converter import convert_multiple_images
 
 app = FastAPI()
 
-# Разрешаем запросы от любых источников (для локального frontend)
+# Настройка CORS. Разрешённые источники можно задать через переменную
+# окружения FRONTEND_ORIGINS (список URL через запятую). По умолчанию
+# разрешены все источники.
+frontend_origins = os.getenv("FRONTEND_ORIGINS", "*")
+allowed_origins = (
+    [origin.strip() for origin in frontend_origins.split(",")]
+    if frontend_origins != "*"
+    else ["*"]
+)
+
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
+    allow_origins=allowed_origins,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],


### PR DESCRIPTION
## Summary
- make CORS whitelist configurable using `FRONTEND_ORIGINS`
- document the env var in backend README

## Testing
- `python -m py_compile backend/main.py backend/converter.py`

------
https://chatgpt.com/codex/tasks/task_e_68529f91207c832daf645950ba68eaeb