### PR TITLE
Add validation for uploads

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -1,17 +1,18 @@
 
 # 🖼️ Image Converter (FastAPI backend)
 
-This is a FastAPI-based backend for converting up to 10 uploaded images to the desired format (PNG, JPEG, WEBP), returning them as a single ZIP archive.
+This is a FastAPI-based backend for converting up to 10 uploaded images to the desired format (PNG, JPEG, WEBP), returning them as a single ZIP archive. Each uploaded file must not exceed 5&nbsp;MB.
 
 ---
 
 ## 🔧 Features
 
 - Endpoint: `POST /convert`
-- Accepts up to 10 images via multipart form
+- Accepts up to 10 images via multipart form (max 5&nbsp;MB each)
 - Returns a ZIP archive with converted images
 - Uses `Pillow` and `python-multipart`
 - Separated logic in `converter.py`
+- Format parameter must be one of `png`, `jpeg`, or `webp`
 
 ---
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -2,8 +2,8 @@ from fastapi import FastAPI, File, UploadFile, Form
 from fastapi.responses import StreamingResponse
 from fastapi.middleware.cors import CORSMiddleware
 from typing import List
-from io import BytesIO
 from converter import convert_multiple_images
+from validation import validate_uploads
 
 app = FastAPI()
 
@@ -21,6 +21,9 @@ async def convert(
     files: List[UploadFile] = File(...),
     format: str = Form(...)
 ):
+    # Validation
+    validate_uploads(files, format)
+
     # Обработка файлов и упаковка в ZIP
     zip_io = await convert_multiple_images(files, format)
 
@@ -31,3 +34,4 @@ async def convert(
             "Content-Disposition": "attachment; filename=converted_images.zip"
         }
     )
+

--- a/backend/validation.py
+++ b/backend/validation.py
@@ -1,0 +1,22 @@
+from typing import List
+from fastapi import UploadFile, HTTPException
+
+MAX_FILES = 10
+MAX_FILE_SIZE = 5 * 1024 * 1024  # 5 MB
+VALID_FORMATS = ["png", "jpeg", "webp"]
+
+
+def validate_uploads(files: List[UploadFile], fmt: str) -> None:
+    """Validate uploaded files and target format."""
+    if len(files) > MAX_FILES:
+        raise HTTPException(status_code=400, detail=f"No more than {MAX_FILES} files allowed")
+
+    if fmt.lower() not in VALID_FORMATS:
+        raise HTTPException(status_code=400, detail=f"Invalid format '{fmt}'. Valid options: {', '.join(VALID_FORMATS)}")
+
+    for file in files:
+        file.file.seek(0, 2)
+        size = file.file.tell()
+        file.file.seek(0)
+        if size > MAX_FILE_SIZE:
+            raise HTTPException(status_code=400, detail=f"File '{file.filename}' exceeds {MAX_FILE_SIZE // (1024 * 1024)} MB limit")


### PR DESCRIPTION
## Summary
- validate upload limits and format
- document upload limits in backend README

## Testing
- `python -m py_compile backend/*.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68529f8c508c832da120aee2fa84bb8c