### PR TITLE
Fix filename sanitization

### DIFF
--- a/backend/converter.py
+++ b/backend/converter.py
@@ -3,6 +3,8 @@ from io import BytesIO
 from zipfile import ZipFile
 from typing import List
 from fastapi import UploadFile
+import os
+import re
 
 async def convert_multiple_images(files: List[UploadFile], target_format: str) -> BytesIO:
     zip_io = BytesIO()
@@ -23,7 +25,10 @@ async def convert_multiple_images(files: List[UploadFile], target_format: str) -
             output_io.seek(0)
 
             # Добавление в ZIP с оригинальным именем
-            base_name = file.filename.rsplit('.', 1)[0]
+            # Защита от передачи путей в имени файла
+            sanitized = os.path.basename(file.filename)
+            sanitized = re.sub(r"[\\/:]+", "_", sanitized)
+            base_name = sanitized.rsplit('.', 1)[0]
             zip_name = f"{base_name}.{target_format.lower()}"
             zip_file.writestr(zip_name, output_io.read())
 

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -1,0 +1,22 @@
+import zipfile
+from io import BytesIO
+from fastapi import UploadFile
+from PIL import Image
+import pytest
+
+from backend.converter import convert_multiple_images
+
+@pytest.mark.asyncio
+async def test_sanitize_path_components():
+    img = Image.new("RGB", (1, 1), color="red")
+    buf = BytesIO()
+    img.save(buf, format="PNG")
+    buf.seek(0)
+
+    upload = UploadFile(buf, filename="../nested/evil.png")
+    result = await convert_multiple_images([upload], "jpeg")
+
+    with zipfile.ZipFile(result) as z:
+        names = z.namelist()
+    assert names == ["evil.jpeg"]
+


### PR DESCRIPTION
## Summary
- sanitize filenames in `convert_multiple_images`
- ensure paths like `../` are stripped in zip names
- add regression test verifying sanitized zip entry

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'PIL')*
- `pip install -r backend/requirements.txt` *(fails to fetch packages)*

------
https://chatgpt.com/codex/tasks/task_e_68529f875698832dbbd2da73de4f24d4