### PR TITLE
Fix redundant splice call in frontend

### DIFF
--- a/frontend/script.js
+++ b/frontend/script.js
@@ -169,7 +169,6 @@ document.getElementById('convertForm').addEventListener('submit', async (e) => {
       output.textContent = `⚠ Only ${remaining} of ${unconvertedIndexes.length} new images will be converted due to limits.`;
       unconvertedIndexes.length = remaining;
       if (unconvertedIndexes.length === 0) {
-        unconvertedIndexes.splice(remaining);
         output.textContent = "❌ Daily usage limit exceeded. No more images can be converted today.";
         isConverting = false;
         return;


### PR DESCRIPTION
## Summary
- remove `unconvertedIndexes.splice(remaining)` because the array length is already set

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68529f95bb10832db1fc3ef2ff59f8bc